### PR TITLE
Fixed PHP Warning when mileage is empty

### DIFF
--- a/src/Helper/Format.php
+++ b/src/Helper/Format.php
@@ -49,7 +49,7 @@ abstract class Format {
 		/** @var Settings $settings */
 		$settings = wp_car_manager()->service( 'settings' );
 
-		return number_format( $mileage, 0, $settings->get_option( 'decimal_separator' ), $settings->get_option( 'thousand_separator' ) ) . ' ' . $settings->get_option( 'distance_unit' );
+		return number_format( $mileage ? $mileage : 0, 0, $settings->get_option( 'decimal_separator' ), $settings->get_option( 'thousand_separator' ) ) . ' ' . $settings->get_option( 'distance_unit' );
 	}
 
 }


### PR DESCRIPTION
```
[11-Aug-2015 23:21:02 UTC] PHP Warning:  number_format() expects parameter 1 to be double, string given in wp-car-manager/src/Helper/Format.php on line 54
```
