### PR TITLE
Autofocus on the 'name' field for more smooth UX

### DIFF
--- a/assets/js/edit-make-model.js
+++ b/assets/js/edit-make-model.js
@@ -1,3 +1,6 @@
 jQuery( function ( $ ) {
     Tipped.create( '.wpcm-has-tip',  { position: 'left' } );
+    
+    // Autofocus on 'Name' field
+    $( '#tag-name' ).focus();
 } );


### PR DESCRIPTION
When entering the `makes`, `features` or `modals` page, automatically focus on the first field on the page for a easier and smoother user experience.

![image](https://cloud.githubusercontent.com/assets/5774447/14411484/f0e3b54a-ff49-11e5-8333-4912b2569707.png)
