### PR TITLE
Fixes #213 - wp_update_post doesn't return WP_Error by default

### DIFF
--- a/src/Vehicle/WordPressRepository.php
+++ b/src/Vehicle/WordPressRepository.php
@@ -166,7 +166,7 @@ class WordPressRepository implements VehicleRepository {
 				'post_author'  => $vehicle->get_author(),
 				'post_type'    => PostType::VEHICLE,
 				'post_status'  => $vehicle->get_status()
-			) );
+			), true );
 
 			if ( is_wp_error( $vehicle_id ) ) {
 				throw new \Exception( 'Unable to insert post in WordPress database' );


### PR DESCRIPTION
Fixes occurrence of wp_insert_post followed by is_wp_error()->throw but default is not to return WP_Error so will never throw (#213).